### PR TITLE
Correction de l'anomalie de l'application habilitations2024

### DIFF
--- a/habilitations2024/controller/FrmHabilitationsController.cs
+++ b/habilitations2024/controller/FrmHabilitationsController.cs
@@ -112,20 +112,19 @@ namespace habilitations2024.controller
         /// <returns></returns>
         public bool PwdFort(string pwd)
         {
-            if (pwd.Length < 8 && pwd.Length > 30)
+            if (pwd.Length < 8 || pwd.Length > 30)
                 return false;
-            if (!Regex.Match(pwd, @"[a-z]").Success)
+            if (!Regex.Match(pwd, @"\p{Ll}").Success)
                 return false;
-            if (!Regex.Match(pwd, @"[A-Z]").Success)
+            if (!Regex.Match(pwd, @"\p{Lu}").Success)
                 return false;
             if (!Regex.Match(pwd, @"[0-9]").Success)
                 return false;
-            if (!Regex.Match(pwd, @"\W").Success)
+            if (!Regex.Match(pwd, @"[\W_]").Success)
                 return false;
             if (Regex.Match(pwd, @"\s").Success)
                 return false;
             return true;
         }
-
     }
 }


### PR DESCRIPTION
Bonjour,
Je vous prie de bien vouloir trouver ci-dessous, les différentes modifications que j’ai apportées dans le code de l’application « habilitations2024 » afin de corriger les problèmes de mot de passe présentés dans la séance 2 de la séquence 1 de la compétence 2 du Bloc 2 SLAM.

**Correction du problème n°1 :**
Changement de l’opérateur « && » de la première condition « if » de la classe « public bool PwdFort » de « FrmHabilitationsController », en opérateur « || » (signifiant OU), afin que le mot de passe ne soit pas inférieur à 8 caractères ou supérieur à 30 caractères et non pas inférieur à 8 caractères et supérieur à 30 caractères.

La ligne de code en question devient ainsi : « if (pwd.Length < 8 || pwd.Length > 30) »

**Correction du problème n°2 :**
L’expression « \W » qui désigne tout caractère non-alphanumérique, exclut l’underscore du fait que celui-ci est considéré comme un caractère alphanumérique en expressions régulières.
Ainsi, il suffit simplement d’ajouter un underscore juste après l’expression « \W » et des crochets de part et d’autre de cette expression, dans la classe « public bool PwdFort » de « FrmHabilitationsController », afin que l’underscore soit inclut parmi les caractères spéciaux.

La ligne de code en question passe ainsi de : « if (!Regex.Match(pwd, @"\W").Success) »
A : « if (!Regex.Match(pwd, @"[\W_]").Success) »

**Correction du problème n°3 :**
Les expressions [a-z] et [A-Z] des conditions « if (!Regex.Match(pwd, @"[a-z]").Success) » et « if (!Regex.Match(pwd, @"[A-Z]").Success) » de la classe « public bool PwdFort » de « FrmHabilitationsController » ne reconnaissent que les lettres non-accentuées, d’où le refus du mot de passe « MôMPREM1éRPWDFôRT! » qui contient de nombreuses lettres accentuées.
Ainsi, il faut remplacer ces deux expressions par les catégories Unicode « \p{Ll} » et « \p{Lu} » qui comprennent respectivement toutes les minuscules et toutes les majuscules, mais également celles qui sont accentuées.

Les lignes de code en question passent ainsi de : « if (!Regex.Match(pwd, @"[a-z]").Success) » et « if (!Regex.Match(pwd, @"[A-Z]").Success) »
A : « if (!Regex.Match(pwd, @"\p{Lu}").Success) » et « if (!Regex.Match(pwd, @"\p{Ll}").Success) »

Avec ces modifications, les trois problèmes présentés sont normalement résolus.

Je vous remercie par avance pour votre prise en charge de ce pull request et vous souhaite une bonne journée.
Bien cordialement,

Matthew Launay